### PR TITLE
slim down `sqlite3-wrapper`

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,16 +17,16 @@ build_pkg () {
 
   sed -i '' 's|const originalInit = self.sqlite3InitModule;|const originalInit = sqlite3InitModule;|g' dist/sqlite3.js
 
-  sed -i '' "s|const W = new Worker(options.proxyUri);|const W = wrapper.makeProxyWorker();|g" dist/sqlite3.js
+  sed -i '' "s|const W = new Worker(options.proxyUri);|const W = new Worker(new URL(options.proxyUri, import.meta.url));|g" dist/sqlite3.js
 
-  sed -i '' "s|wasmBinaryFile = 'sqlite3.wasm';|wasmBinaryFile = wrapper.wasmBinaryFile;|g" dist/sqlite3.js
+  sed -i '' "s|wasmBinaryFile = 'sqlite3.wasm';|wasmBinaryFile = new URL('sqlite3.wasm', import.meta.url).href|g" dist/sqlite3.js
 
   sed -i '' "s|wasmBinaryFile = locateFile(wasmBinaryFile)|// wasmBinaryFile = locateFile(wasmBinaryFile)|g" dist/sqlite3.js
 
   # prevent warn log message (even during dev)
   sed -i '' "s|console.warn(\"Installing sqlite3|// console.warn(\"Installing sqlite3|g" dist/sqlite3.js
 
-  sed -i '' "s|Module\['locateFile'\] = function(path, prefix) {|Module\['locateFile'\] = function(path, prefix) { return wrapper.wasmBinaryFile;|" dist/sqlite3.js
+  sed -i '' "s|Module\['locateFile'\] = function(path, prefix) {|Module\['locateFile'\] = function(path, prefix) { return new URL(path, import.meta.url).href;|" dist/sqlite3.js
 
   cp ../../build/sqlite3-wrapper.js dist/sqlite3-wrapper.js
 }

--- a/build/sqlite3-wrapper.js
+++ b/build/sqlite3-wrapper.js
@@ -1,12 +1,6 @@
 import install from "./sqlite3.js";
 
 const wrapper = {};
-// these calls need to happen within a ESM module for Vite's magic to work
-const proxyWorkerUrl = new URL("sqlite3-opfs-async-proxy.js", import.meta.url)
-  .href;
-wrapper.makeProxyWorker = () => new Worker(proxyWorkerUrl, { type: "module" });
-
-wrapper.wasmBinaryFile = new URL("sqlite3.wasm", import.meta.url).href;
 
 const init = () => {
   install(wrapper);

--- a/packages/example/src/crsqlite.ts
+++ b/packages/example/src/crsqlite.ts
@@ -30,6 +30,11 @@ db.exec({
 });
 console.log(rows[0]);
 
+// you _MUST_ run this before closing `crsql` db connections
+// see -- https://sqlite.org/forum/forumpost/a38be46f01
+db.exec("SELECT crsql_finalize()");
+db.close();
+
 // Spawning into a worker
 console.log("Try running the db in a worker");
 new Worker(new URL("./crsqlite-worker.ts", import.meta.url), {

--- a/packages/example/src/sqlite.ts
+++ b/packages/example/src/sqlite.ts
@@ -16,6 +16,7 @@ db.exec({
   rowMode: "object",
 });
 console.log(rows);
+db.close();
 
 console.log("Try running the db in a worker");
 new Worker(new URL("./sqlite-worker.ts", import.meta.url), {


### PR DESCRIPTION
Plan with this and future commits is to have as little code wrapping sqlite3.js as possible as well as minimal modifications to `sqlite3.js` so we can submit the changes to sqlite and explain what is going on to them.

